### PR TITLE
Htsb 47 def add point func

### DIFF
--- a/app/crud/relationship.py
+++ b/app/crud/relationship.py
@@ -52,3 +52,26 @@ def update_relationship_trust_level(db: Session, user_id: int, character_id: int
     db.commit()
     db.refresh(db_relationship)
     return RelationshipResponse.from_orm(db_relationship)
+
+
+def update_relationship_total_point(db: Session, user_id: int, character_id: int, points_to_add: int) -> RelationshipResponse:
+    """
+    指定したユーザーIDとキャラクターIDに紐づく信頼関係のtotal_pointsにポイントを加算する
+    加算するポイントを引数とする（points_to_add）
+    points_to_addは正の値であることを想定
+    """
+    db_relationship = db.query(Relationship).filter(
+        Relationship.user_id == user_id,
+        Relationship.character_id == character_id
+    ).first()
+
+    if not db_relationship:
+        return RelationshipResponse()
+
+    if db_relationship.total_points is None:
+        db_relationship.total_points = 0
+
+    db_relationship.total_points += points_to_add
+    db.commit()
+    db.refresh(db_relationship)
+    return RelationshipResponse.from_orm(db_relationship)


### PR DESCRIPTION
relationshipテーブルのtotal_pointを更新する関数を追加
    """
    指定したユーザーIDとキャラクターIDに紐づく信頼関係のtotal_pointsにポイントを加算する
    加算するポイントを引数とする（points_to_add）
    points_to_addは正の値であることを想定
    """

変更
ht-sb-hackathon-backend/app/crud/relationship.py
　　update_relationship_total_pointを作成