### PR TITLE
Htsb 103 add occupation endpoint

### DIFF
--- a/app/api/v1/api.py
+++ b/app/api/v1/api.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter
 
-from .endpoints import achivement, auth, character, city, file, healthcheck, tasuki, user, occupation
+from .endpoints import achivement, auth, character, city, file, healthcheck, occupation, tasuki, user
 
 api_router = APIRouter()
 

--- a/app/api/v1/api.py
+++ b/app/api/v1/api.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter
 
-from .endpoints import achivement, auth, character, city, file, healthcheck, tasuki, user
+from .endpoints import achivement, auth, character, city, file, healthcheck, tasuki, user, occupation
 
 api_router = APIRouter()
 
@@ -16,5 +16,6 @@ api_router.include_router(user.router, prefix="/users", tags=["users"])
 api_router.include_router(tasuki.router, prefix="/tasuki", tags=["tasuki"])
 api_router.include_router(file.router, prefix="/files", tags=["files"])
 api_router.include_router(city.router, prefix="/cities", tags=["cities"])
+api_router.include_router(occupation.router, prefix="/occupations", tags=["occupations"])
 api_router.include_router(character.router, prefix="/characters", tags=["characters"])
 api_router.include_router(achivement.router, prefix="/achivements", tags=["achivements"])

--- a/app/api/v1/endpoints/occupation.py
+++ b/app/api/v1/endpoints/occupation.py
@@ -1,0 +1,37 @@
+from typing import List
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from app.api import deps
+from app.crud import occupation as crud
+from app.schemas import occupation as schemas
+from app.models import user as user_model
+
+router = APIRouter()
+
+@router.get("/", response_model=List[schemas.OccupationResponse])
+def read_occupations(
+    db: Session = Depends(deps.get_db),
+    current_user: user_model.User = Depends(deps.get_current_active_user),
+) -> List[schemas.OccupationResponse]:
+    """
+    職業一覧を取得
+    """
+    occupations = crud.get_occupations(db)
+    return occupations
+
+@router.get("/{occupation_id}", response_model=schemas.OccupationResponse)
+def read_occupation(
+    *,
+    db: Session = Depends(deps.get_db),
+    occupation_id: int,
+    current_user: user_model.User = Depends(deps.get_current_active_user),
+) -> schemas.OccupationResponse:
+    """
+    特定の職業情報を取得
+    """
+    occupation = crud.get_occupation(db, occupation_id=occupation_id)
+    if not occupation:
+        raise HTTPException(status_code=404, detail="Occupation not found")
+    return occupation

--- a/app/api/v1/endpoints/occupation.py
+++ b/app/api/v1/endpoints/occupation.py
@@ -5,8 +5,8 @@ from sqlalchemy.orm import Session
 
 from app.api import deps
 from app.crud import occupation as crud
-from app.schemas import occupation as schemas
 from app.models import user as user_model
+from app.schemas import occupation as schemas
 
 router = APIRouter()
 

--- a/app/crud/occupation.py
+++ b/app/crud/occupation.py
@@ -1,0 +1,23 @@
+from typing import List
+
+from sqlalchemy.orm import Session
+
+from app.models.occupation import Occupation
+from app.schemas.occupation import OccupationResponse
+
+
+def get_occupations(db: Session) -> List[OccupationResponse]:
+    """
+    全ての職業情報を取得
+    """
+    occupations = db.query(Occupation).all()
+    return [OccupationResponse.from_orm(occupation) for occupation in occupations]
+
+def get_occupation(db: Session, occupation_id: int) -> OccupationResponse | None:
+    """
+    特定の職業情報を取得
+    """
+    occupation = db.query(Occupation).filter(Occupation.id == occupation_id).first()
+    if occupation:
+        return OccupationResponse.from_orm(occupation)
+    return None


### PR DESCRIPTION
## 概要

職業（Occupation）テーブルのデータを取得するためのAPIエンドポイントを追加

## 主な変更点

1.  **職業情報取得APIの追加**
    *   `GET /api/v1/occupations/`: 全ての職業情報をリスト形式で返却します。
    *   `GET /api/v1/occupations/{occupation_id}`: 指定されたIDの職業情報を返却します。

2.  **関連ファイルの作成・更新**
    *   **新規作成**:
        *   `ht-sb-hackathon-backend/app/crud/occupation.py`
        *   `ht-sb-hackathon-backend/app/api/v1/endpoints/occupation.py`
    *   **更新**:
        *   `ht-sb-hackathon-backend/app/api/v1/api.py`
