### PR TITLE
キャラクターごとのチャット情報に最終会話日時を含めるように変更

### DIFF
--- a/app/schemas/chat.py
+++ b/app/schemas/chat.py
@@ -1,5 +1,5 @@
-from typing import Dict, List, Optional
 from datetime import datetime
+from typing import Dict, List, Optional
 
 from pydantic import BaseModel, Field
 

--- a/app/schemas/chat.py
+++ b/app/schemas/chat.py
@@ -1,4 +1,5 @@
 from typing import Dict, List, Optional
+from datetime import datetime
 
 from pydantic import BaseModel, Field
 
@@ -34,6 +35,7 @@ class ChatCount(BaseModel):
 
     character_id: int = Field(..., description="Character ID")
     count: int = Field(..., ge=0, description="Number of chats with the character")
+    last_chat_date: Optional[datetime] = Field(default=None, description="Date of the last chat with the character")
 
     class Config:
         orm_mode = True


### PR DESCRIPTION
## 概要
キャラクターごとのチャット数を取得するAPIレスポンスに、各キャラクターとの最終会話日時を追加

## 変更点

- **スキーマの更新 (`app/schemas/chat.py`)**:
    - `ChatCount` モデルに `last_chat_date` (Optional[datetime]) フィールドを追加

- **CRUD処理の更新 (`app/crud/tasuki.py`)**:
    - `get_all_chat_count_by_character`
        - `$group` ステージで最終会話日時 (`last_chat_date: {"$max": "$timestamp"}`) を集計
        - `$project` ステージで、`last_chat_date` を含めるように変更
    - アグリゲーション結果から `last_chat_date` （ISO形式の文字列）を取得し、Pythonの `datetime` オブジェクトに変換